### PR TITLE
Rework API and usage

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -26,6 +26,7 @@ justin = ">= 1.0.1 and < 2.0.0"
 glance = { git = "https://github.com/qezz/glance.git", ref = "eacc06769c49ddf161c67c2948b8fce5c041ac1f" }
 gleam_yielder = ">= 1.1.0 and < 2.0.0"
 argv = ">= 1.0.2 and < 2.0.0"
+filepath = ">= 1.1.2 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.6.1 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -21,6 +21,7 @@ packages = [
 [requirements]
 argv = { version = ">= 1.0.2 and < 2.0.0" }
 dot_env = { version = ">= 1.2.0 and < 2.0.0" }
+filepath = { version = ">= 1.1.2 and < 2.0.0" }
 fswalk = { version = ">= 3.0.3 and < 4.0.0" }
 glance = { git = "https://github.com/qezz/glance.git", ref = "eacc06769c49ddf161c67c2948b8fce5c041ac1f" }
 gleam_json = { version = ">= 3.0.2 and < 4.0.0" }

--- a/src/common.gleam
+++ b/src/common.gleam
@@ -1,11 +1,14 @@
 import gleam/string
 import justin
 
+// NOTE: Practically speaking, if the module is called `cat_json.gleam`,
+// and the usage is as `cat_json.get_decoder_cat()`, we can shorten it
+// to `cat_json.decoder()` or similar.
 pub fn decoder_name_of_t(raw_name: String) -> String {
   let snake_name = justin.snake_case(raw_name)
   let name = case string.ends_with(snake_name, "_json") {
     True -> string.drop_end(snake_name, 5)
-    False -> raw_name
+    False -> snake_name
   }
   "get_decoder_" <> name
 }

--- a/src/config.gleam
+++ b/src/config.gleam
@@ -1,0 +1,9 @@
+import filter
+
+pub type Params {
+  Params(
+    project_root: String,
+    subpaths_filter: filter.SubpathsFilter,
+    generated_module_suffix: String,
+  )
+}

--- a/src/debug.gleam
+++ b/src/debug.gleam
@@ -1,0 +1,54 @@
+import gleam/function
+import gleam/io
+import gleam/list
+import gleam/string
+
+pub fn inspect(data: t, msg: String, do: Bool, f) -> t {
+  case do {
+    False -> data
+    True -> {
+      io.println(msg)
+      io.println(string.inspect(f(data)))
+
+      data
+    }
+  }
+}
+
+pub fn inspect_print(data: t, msg: String, do_print: Bool) -> t {
+  inspect(data, msg, do_print, function.identity)
+}
+
+pub fn inspect_list(data: List(t), msg: String, do_print: Bool) -> List(t) {
+  case do_print {
+    False -> Nil
+    True -> {
+      io.println(msg)
+
+      data |> list.each(fn(item) { io.println("  " <> string.inspect(item)) })
+
+      Nil
+    }
+  }
+
+  data
+}
+
+pub fn inspect_list_map(
+  data: List(t),
+  msg: String,
+  do_print: Bool,
+  f,
+) -> List(t) {
+  case do_print {
+    False -> Nil
+    True -> {
+      io.println(msg)
+      data
+      |> list.map(f)
+      |> list.each(fn(item) { io.println("  " <> item) })
+    }
+  }
+
+  data
+}

--- a/src/filter.gleam
+++ b/src/filter.gleam
@@ -1,0 +1,4 @@
+pub type SubpathsFilter {
+  All
+  Dirs(List(String))
+}

--- a/src/gserde.gleam
+++ b/src/gserde.gleam
@@ -1,10 +1,15 @@
-import argv
+import config
+import debug
 import evil.{expect}
+import filepath
+import filter
 import fswalk
 import glance
 import gleam/bool
+import gleam/int
 import gleam/io
 import gleam/list
+import gleam/option
 import gleam/result
 import gleam/string
 import gleam/yielder
@@ -12,6 +17,7 @@ import internal/deserializer
 import internal/serializer
 import request.{type Request, Request}
 import simplifile
+import util
 
 pub fn gen(req: Request) {
   let ser =
@@ -35,55 +41,123 @@ fn to_output_filename(src_filename) {
 }
 
 pub fn main() {
-  let path = case argv.load().arguments {
-    [path] -> path
-    _ -> panic as "path to a directory is required as a first argument"
-  }
+  let params =
+    config.Params(
+      project_root: "testproject",
+      subpaths_filter: filter.Dirs(["src"]),
+      generated_module_suffix: "_json",
+    )
 
-  process_path(path)
+  let outputs = process(params, True)
+
+  outputs
+  |> list.each(fn(gf) { simplifile.write(gf.filepath, gf.data) })
 }
 
-pub fn process_path(path: String) {
+pub type ParsedFileResult {
+  ParsedFileResult(
+    filepath: String,
+    module_name: String,
+    mod: Result(glance.Module, glance.Error),
+  )
+}
+
+// For now only supports files from <project_root>/src/...
+pub type CustomFilePath {
+  SrcFilePath(project_root: String, rel_filepath: String, full_path: String)
+}
+
+pub type ParsedFile {
+  ParsedFile(filepath: String, module_name: String, mod: glance.Module)
+}
+
+pub type GeneratedFile {
+  GeneratedFile(filepath: String, module_name: String, data: String)
+}
+
+fn find_gleam_files(root: String) -> List(CustomFilePath) {
   fswalk.builder()
-  |> fswalk.with_path(path)
-  |> fswalk.with_traversal_filter(fn(it) {
-    string.ends_with(it.filename, ".gleam") && !it.stat.is_directory
-  })
+  |> fswalk.with_path(root)
+  // |> fswalk.with_traversal_filter(fn(it) {
+  //   string.ends_with(it.filename, ".gleam") && !it.stat.is_directory
+  // })
   |> fswalk.walk
   |> yielder.map(fn(v) { expect(v, "failed to walk").filename })
   |> yielder.filter(fn(v) {
     // I have no idea why the traversal filter still includes directories.
     string.ends_with(v, ".gleam")
   })
-  |> yielder.each(fn(f) { process_single(f, False) })
+  |> yielder.map(fn(fp) {
+    SrcFilePath(
+      project_root: root,
+      rel_filepath: util.filepath_relative_to(fp, root),
+      full_path: fp,
+    )
+  })
+  |> yielder.to_list
 }
 
-pub fn process_single(src_filename: String, is_debug) {
-  bool.guard(!is_debug, Nil, fn() {
-    io.println(string.inspect(#("Processing", src_filename)))
-    Nil
+pub fn process(params: config.Params, verbose: Bool) -> List(GeneratedFile) {
+  debug.inspect_print(params, "Parameters:", verbose)
+
+  let files = case params.subpaths_filter {
+    filter.All -> find_gleam_files(params.project_root)
+    filter.Dirs(dirs) -> {
+      dirs
+      |> list.flat_map(fn(dir) {
+        find_gleam_files(filepath.join(params.project_root, dir))
+      })
+    }
+  }
+
+  files
+  |> debug.inspect_list_map("Filtered files:", verbose, fn(item) {
+    item.rel_filepath
   })
+  |> list.map(fn(cfp) {
+    ParsedFileResult(
+      filepath: cfp.full_path,
+      module_name: result.unwrap(
+        util.module_name_from_rel_filepath(cfp.rel_filepath),
+        "can't derive module name",
+      ),
+      mod: parse_file(cfp.full_path),
+    )
+  })
+  // TODO: filter out files based on TypeFilter
+  |> debug.inspect_list_map("Parsed:", verbose, fn(item) {
+    #(item.filepath, result.map(item.mod, fn(_) { Nil })) |> string.inspect
+  })
+  |> list.map(fn(parsed) {
+    let assert Ok(m) = parsed.mod
+    ParsedFile(parsed.filepath, parsed.module_name, m)
+  })
+  |> list.map(process_single)
+  |> list.filter_map(fn(maybe) { option.to_result(maybe, Nil) })
+  |> debug.inspect_list_map("Processed:", verbose, fn(item: GeneratedFile) {
+    item.filepath
+  })
+}
 
-  let src_module_name =
-    src_filename
-    |> string.replace("src/", "")
-    |> string.replace(".gleam", "")
+pub fn parse_file(filepath: String) -> Result(glance.Module, glance.Error) {
+  let assert Ok(source) = simplifile.read(from: filepath)
 
-  let dest_filename = to_output_filename(src_filename)
+  source |> glance.module()
+}
 
-  let assert Ok(code) = simplifile.read(from: src_filename)
+pub fn process_single(p: ParsedFile) -> option.Option(GeneratedFile) {
+  io.println("Processing: " <> p.filepath)
 
-  let assert Ok(parsed) =
-    glance.module(code)
-    |> result.map_error(fn(err) {
-      io.println(string.inspect(err))
-      panic
-    })
+  let src_module_name = p.module_name
 
-  let custom_types =
-    list.map(parsed.custom_types, fn(def) { def.definition })
-    |> list.filter(fn(x) { string.ends_with(x.name, "Json") })
+  let dest_filename = to_output_filename(p.filepath)
 
+  // TODO: properly filter the custom types
+  let custom_types = list.map(p.mod.custom_types, fn(def) { def.definition })
+
+  // NOTE: It should be possible to allow multiple generated types per file,
+  // but in that case the names of the generated modules and functions
+  // should be carefully crafted.
   bool.guard(
     when: list.length(of: custom_types) <= 1,
     return: Nil,
@@ -92,12 +166,17 @@ pub fn process_single(src_filename: String, is_debug) {
 
   let requests =
     custom_types
+    |> debug.inspect_list_map(
+      "Types: (" <> int.to_string(list.length(custom_types)) <> ")",
+      True,
+      fn(item) { item.name },
+    )
     |> list.flat_map(fn(custom_type) {
       list.map(custom_type.variants, fn(variant) {
         Request(
           src_module_name: src_module_name,
           type_name: custom_type.name,
-          module: parsed,
+          module: p.mod,
           variant: variant,
           ser: True,
           de: True,
@@ -111,18 +190,22 @@ pub fn process_single(src_filename: String, is_debug) {
     |> string.join("\n\n")
 
   case filecontent {
-    "" -> Nil
-    _ ->
-      simplifile.write(
-        to: dest_filename,
-        contents: [
+    "" -> option.None
+    other -> {
+      let content2 =
+        [
           "import gleam/json",
           "import gleam/dynamic/decode",
-          "import " <> src_module_name,
-          filecontent,
+          "import " <> p.module_name,
+          other,
         ]
-          |> string.join("\n"),
-      )
-      |> result.unwrap(Nil)
+        |> string.join("\n")
+
+      option.Some(GeneratedFile(
+        filepath: dest_filename,
+        module_name: p.module_name,
+        data: content2,
+      ))
+    }
   }
 }

--- a/src/util.gleam
+++ b/src/util.gleam
@@ -1,0 +1,36 @@
+import filepath
+import gleam/list
+import gleam/string
+
+/// Hacky 'relative_to' function. Don't use in production.
+pub fn filepath_relative_to(fullpath: String, basepath: String) -> String {
+  let full = filepath.split(fullpath)
+  let base = filepath.split(basepath)
+
+  let difference = list.filter(full, fn(item) { !list.contains(base, item) })
+  difference |> string.join("/")
+}
+
+pub fn module_name_from_rel_filepath(path: String) -> Result(String, Nil) {
+  let expanded =
+    path
+    |> filepath.expand
+
+  case expanded {
+    Ok(exp) -> {
+      exp
+      // |> filepath.split
+      // |> string.join("/")
+      |> filepath.strip_extension
+      |> Ok
+    }
+    e -> {
+      // NOTE: as of (filepath v1.1.2) filepath.expand states
+      // in the docs that it can return `Error("..")` but
+      // the type signature says it returns `Result(String, Nil)`.
+      //
+      // So we can safely return the exact error here.
+      e
+    }
+  }
+}

--- a/test/gserde_test.gleam
+++ b/test/gserde_test.gleam
@@ -1,0 +1,21 @@
+import gleam/list
+import gleeunit
+import util
+
+pub fn main() -> Nil {
+  gleeunit.main()
+}
+
+pub fn module_name_test() {
+  let testcases = [
+    #("cats.gleam", Ok("cats")),
+    #("model/cats.gleam", Ok("model/cats")),
+    #("./src/cats.gleam", Ok("src/cats")),
+    #("../src/cats.gleam", Error(Nil)),
+  ]
+
+  testcases
+  |> list.each(fn(tc) {
+    assert tc.1 == util.module_name_from_rel_filepath(tc.0) as "cats"
+  })
+}


### PR DESCRIPTION
The API should provide a way to specify `Params` and spit out the result based on that.

The users of the library have to write their own small app to process files. In this PR it's planned to provide all the needed handles so it should be easy to write that tool.

Pipeline should be similar to the following:
```gleam
let params = 
    config.Params(
      project_root: "..", // project root, to properly resolve module names
      subpaths_filter: filter.Dirs(["src/model"]), // subset of directories (in this case) to be processed
      gen_filter: filter.Everything, // generated serde for all types
      serde_filter: filter.Both, // generated both serializer and deserializer
    )
```

TODO: add generated file suffix to the params?